### PR TITLE
Add support for restoring the read-only databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,23 @@ Use Visual Studio code with remote containers extension - a configuration is inc
 * Run both `AccountCommandApplication`  and `AccountQueryApplication`
 * Use the sample REST invocations, like in [this folder](./rest-client/) (using [VSC REST Client extension](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)).
 
+# Limitations and disclaimer
+
+This is only a case-study for practicing the concepts - it is not production ready in any way. 
+
+For example, publishing events is done in not transactional way (e.g., there is no Outbox pattern implemented).
+
+You probably want to use existing libraries or frameworks for doing proper CQRS applications, see [this video](https://www.youtube.com/watch?v=_V3C-e0gKoI&ab_channel=DevoxxPoland) for ideas.
+
+# TODO
+- Error handling is missing - using a central `ControllerAdvice` makes sense
+- Unit and integrations are missing - yep, sadly the course was not supporting automatic testing but it should not be a problem to retrofit these.
+  - integration tests are the most difficult since there are many moving pieces around
+  - unit tests should be easy to do 
+
+# References
+
+CQRS is a technical architecture for supporting Domain-Driven Design, so you may want to dive deep in this approach and understand its consequences.
+Besides google'ing and watching videos, you may want to read the following:
+- [Domain Driven Design](https://www.amazon.co.uk/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215) - this is the historical book from Eric Evans, it is not really practical but still valuable. 
+- [Learning Domain-Driven Design](https://www.amazon.co.uk/Learning-Domain-Driven-Design-Aligning-Architecture/dp/1098100131) - this is a great summary, connecting the business modelling and architectural implementation with a lot of examples. It is not providing you with a ready-to-use solution but it gives you the needed high-level views for understanding how business agility and software architectures relates in the DDD context.

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/AccountCommandApplication.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/AccountCommandApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import com.techbank.account.cmd.api.commands.CloseAccountCommand;
 import com.techbank.account.cmd.api.commands.CommandHandler;
 import com.techbank.account.cmd.api.commands.OpenAccountCommand;
+import com.techbank.account.cmd.api.commands.RestoreReadDbCommand;
 import com.techbank.account.cmd.api.commands.DepositFundsCommand;
 import com.techbank.account.cmd.api.commands.WithdrawFundsCommand;
 import com.techbank.cqrs.core.infrastructure.CommandDispatcher;
@@ -31,5 +32,6 @@ public class AccountCommandApplication {
 		commandDispatcher.registerHandler(DepositFundsCommand.class, commandHandler::handle);
 		commandDispatcher.registerHandler(WithdrawFundsCommand.class, commandHandler::handle);
 		commandDispatcher.registerHandler(CloseAccountCommand.class, commandHandler::handle);
+		commandDispatcher.registerHandler(RestoreReadDbCommand.class, commandHandler::handle);
 	}
 }

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/api/commands/AccountCommandHandler.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/api/commands/AccountCommandHandler.java
@@ -45,4 +45,9 @@ public class AccountCommandHandler implements CommandHandler {
 
         eventSourcingHandler.save(aggregate);
     }
+
+    @Override
+    public void handle(final RestoreReadDbCommand command) {
+        eventSourcingHandler.republishEvents();
+    }
 }

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/api/commands/CommandHandler.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/api/commands/CommandHandler.java
@@ -5,4 +5,5 @@ public interface CommandHandler {
     void handle(DepositFundsCommand command);
     void handle(WithdrawFundsCommand command);
     void handle(CloseAccountCommand command);
+    void handle(RestoreReadDbCommand command);
 }

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/api/commands/RestoreReadDbCommand.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/api/commands/RestoreReadDbCommand.java
@@ -1,0 +1,10 @@
+package com.techbank.account.cmd.api.commands;
+
+import com.techbank.cqrs.core.commands.BaseCommand;
+
+/**
+ * Force recreation of the read-only views.
+ */
+public class RestoreReadDbCommand extends BaseCommand {
+
+}

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/api/controllers/RestoreReadDbController.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/api/controllers/RestoreReadDbController.java
@@ -1,0 +1,35 @@
+package com.techbank.account.cmd.api.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.techbank.account.cmd.api.commands.RestoreReadDbCommand;
+import com.techbank.account.common.dto.BaseResponse;
+import com.techbank.cqrs.core.infrastructure.CommandDispatcher;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Administrative entrypoint for recreating all read-only views.
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/admin/restore-read-db")
+public class RestoreReadDbController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestoreReadDbController.class);
+
+    private final CommandDispatcher commandDispatcher;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse> restoreReadOnlyDatabases() {
+        commandDispatcher.send(new RestoreReadDbCommand());
+
+        // TODO Add proper exception handling
+        return new ResponseEntity<>(new BaseResponse("Restore request for read-only database(s) completed successfully!"), HttpStatus.CREATED);
+    }
+}

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/domain/AccountAggregate.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/domain/AccountAggregate.java
@@ -103,4 +103,8 @@ public class AccountAggregate extends AggregateRoot {
     public void apply(final AccountClosedEvent event) {
         this.isActive = false;
     }
+
+    public boolean isActive() {
+        return isActive;
+    }
 }

--- a/account/account-cmd/src/main/java/com/techbank/account/cmd/infrastructure/AccountEventStore.java
+++ b/account/account-cmd/src/main/java/com/techbank/account/cmd/infrastructure/AccountEventStore.java
@@ -64,5 +64,14 @@ public class AccountEventStore implements EventStore {
 
         return eventStream.stream().map(event -> event.getEventData() ).toList();
     }
-    
+
+    @Override
+    public List<String> getAggregateIds() {
+        final var eventStream = eventStoreRepository.findAll();
+        if (eventStream == null || eventStream.isEmpty()) {
+            throw new IllegalStateException("Could not find any events in the event store.");
+        }
+
+        return eventStream.stream().map(EventModel::getAggregateId).toList();
+    }
 }

--- a/account/account-common/src/main/java/com/techbank/account/common/dto/BaseResponse.java
+++ b/account/account-common/src/main/java/com/techbank/account/common/dto/BaseResponse.java
@@ -3,8 +3,9 @@ package com.techbank.account.common.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-@Data @NoArgsConstructor  @AllArgsConstructor
+@Data @NoArgsConstructor  @AllArgsConstructor @SuperBuilder
 public class BaseResponse {
     private String message;
 }

--- a/account/account-query/src/main/java/com/techbank/account/query/AccountQueryApplication.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/AccountQueryApplication.java
@@ -1,13 +1,37 @@
 package com.techbank.account.query;
 
+import javax.annotation.PostConstruct;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import com.techbank.account.query.api.queries.FindAccountByHolderQuery;
+import com.techbank.account.query.api.queries.FindAccountByIdQuery;
+import com.techbank.account.query.api.queries.FindAccountsWithBalanceQuery;
+import com.techbank.account.query.api.queries.FindAllAccountsQuery;
+import com.techbank.account.query.api.queries.QueryHandler;
+import com.techbank.cqrs.core.infrastructure.QueryDispatcher;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @SpringBootApplication
 public class AccountQueryApplication {
 
+	private final QueryHandler queryHandler;
+
+	private final QueryDispatcher queryDispatcher;
+
 	public static void main(String[] args) {
 		SpringApplication.run(AccountQueryApplication.class, args);
+	}
+
+	@PostConstruct
+	public void registerHandlers() {
+		queryDispatcher.registerHandler(FindAllAccountsQuery.class, queryHandler::handle);
+		queryDispatcher.registerHandler(FindAccountByIdQuery.class, queryHandler::handle);
+		queryDispatcher.registerHandler(FindAccountByHolderQuery.class, queryHandler::handle);
+		queryDispatcher.registerHandler(FindAccountsWithBalanceQuery.class, queryHandler::handle);
 	}
 
 }

--- a/account/account-query/src/main/java/com/techbank/account/query/api/controllers/AccountLookupController.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/controllers/AccountLookupController.java
@@ -1,0 +1,74 @@
+package com.techbank.account.query.api.controllers;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.techbank.account.query.api.dto.AccountLookupResponse;
+import com.techbank.account.query.api.dto.EqualityType;
+import com.techbank.account.query.api.queries.FindAccountByHolderQuery;
+import com.techbank.account.query.api.queries.FindAccountByIdQuery;
+import com.techbank.account.query.api.queries.FindAccountsWithBalanceQuery;
+import com.techbank.account.query.api.queries.FindAllAccountsQuery;
+import com.techbank.account.query.domain.BankAccount;
+import com.techbank.cqrs.core.infrastructure.QueryDispatcher;
+import com.techbank.cqrs.core.queries.BaseQuery;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/bank-account-lookup")
+public class AccountLookupController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccountLookupController.class);
+
+    private final QueryDispatcher queryDispatcher;
+
+    @GetMapping("/")
+    public ResponseEntity<AccountLookupResponse> findAllAccounts() {
+        return executeQuery(new FindAllAccountsQuery());
+    }
+
+    @GetMapping("/by-id/{id}")
+    public ResponseEntity<AccountLookupResponse> findAccountById(@PathVariable("id") final String id) {
+        return executeQuery(new FindAccountByIdQuery(id));
+    }
+
+    @GetMapping("/by-holder/{holderName}")
+    public ResponseEntity<AccountLookupResponse> findAccountByHolder(@PathVariable("holderName") final String holderName) {
+        return executeQuery(new FindAccountByHolderQuery(holderName));
+    }
+
+
+    @GetMapping("/by-balance")
+    public ResponseEntity<AccountLookupResponse> findAccountByBalance(@RequestParam("balance") final BigDecimal balance, @RequestParam("equalityType") final EqualityType equalityType) {
+        return executeQuery(new FindAccountsWithBalanceQuery(
+            equalityType, balance
+        ));
+    }
+
+    private ResponseEntity<AccountLookupResponse> executeQuery(final BaseQuery query) {
+        final List<BankAccount> bankAccounts = queryDispatcher.send(query);
+
+        if (bankAccounts.isEmpty()) {
+            return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
+        }
+
+        final var response = AccountLookupResponse.builder()
+            .accounts(bankAccounts)
+            .message(String.format("Successfully found %d accounts", bankAccounts.size()))
+            .build();
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/dto/AccountLookupResponse.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/dto/AccountLookupResponse.java
@@ -1,0 +1,20 @@
+package com.techbank.account.query.api.dto;
+
+import java.util.List;
+
+import com.techbank.account.common.dto.BaseResponse;
+import com.techbank.account.query.domain.BankAccount;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data @SuperBuilder
+@NoArgsConstructor
+public class AccountLookupResponse extends BaseResponse {
+    private List<BankAccount> accounts;
+
+    public AccountLookupResponse(final String message) {
+        super(message);
+    }
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/dto/EqualityType.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/dto/EqualityType.java
@@ -1,0 +1,6 @@
+package com.techbank.account.query.api.dto;
+
+public enum EqualityType {
+    GREATER_THAN,
+    LESS_THAN
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAccountByHolderQuery.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAccountByHolderQuery.java
@@ -1,0 +1,11 @@
+package com.techbank.account.query.api.queries;
+
+import com.techbank.cqrs.core.queries.BaseQuery;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data @AllArgsConstructor
+public class FindAccountByHolderQuery extends BaseQuery {
+    private String accountHolder;
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAccountByIdQuery.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAccountByIdQuery.java
@@ -1,0 +1,14 @@
+package com.techbank.account.query.api.queries;
+
+import com.techbank.cqrs.core.queries.BaseQuery;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data @AllArgsConstructor
+public class FindAccountByIdQuery extends BaseQuery {
+    /**
+     * Bank account id.
+     */
+    private String id;
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAccountsWithBalanceQuery.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAccountsWithBalanceQuery.java
@@ -1,0 +1,15 @@
+package com.techbank.account.query.api.queries;
+
+import java.math.BigDecimal;
+
+import com.techbank.account.query.api.dto.EqualityType;
+import com.techbank.cqrs.core.queries.BaseQuery;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data @AllArgsConstructor
+public class FindAccountsWithBalanceQuery extends BaseQuery {
+    private EqualityType equalityType;
+    private BigDecimal amount;
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAllAccountsQuery.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/queries/FindAllAccountsQuery.java
@@ -1,0 +1,7 @@
+package com.techbank.account.query.api.queries;
+
+import com.techbank.cqrs.core.queries.BaseQuery;
+
+public class FindAllAccountsQuery extends BaseQuery {
+    
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/api/queries/QueryHandler.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/api/queries/QueryHandler.java
@@ -1,0 +1,12 @@
+package com.techbank.account.query.api.queries;
+
+import java.util.List;
+
+import com.techbank.cqrs.core.domain.BaseEntity;
+
+public interface QueryHandler {
+    List<BaseEntity> handle(FindAllAccountsQuery query);
+    List<BaseEntity> handle(FindAccountByIdQuery query);
+    List<BaseEntity> handle(FindAccountByHolderQuery query);
+    List<BaseEntity> handle(FindAccountsWithBalanceQuery query);
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/infrastructure/AccountQueryDispatcher.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/infrastructure/AccountQueryDispatcher.java
@@ -1,0 +1,41 @@
+package com.techbank.account.query.infrastructure;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.techbank.cqrs.core.domain.BaseEntity;
+import com.techbank.cqrs.core.infrastructure.QueryDispatcher;
+import com.techbank.cqrs.core.queries.BaseQuery;
+import com.techbank.cqrs.core.queries.QueryHandlerMethod;
+
+@Service
+public class AccountQueryDispatcher implements QueryDispatcher {
+
+    private final Map<Class<? extends BaseQuery>, List<QueryHandlerMethod>> routes = new HashMap<>();
+
+    @Override
+    public <T extends BaseQuery> void registerHandler(Class<T> type, QueryHandlerMethod<T> handler) {
+        // TODO Auto-generated method stub
+        final var handlers = routes.computeIfAbsent(type, c -> new LinkedList<>());
+
+        handlers.add(handler);
+    }
+
+    @Override
+    public <U extends BaseEntity> List<U> send(BaseQuery query) {
+        final var handlers = routes.get(query.getClass());
+
+        if (handlers == null || handlers.isEmpty()) {
+            throw new RuntimeException("No handler found for this query type.");
+        }
+        if (handlers.size() > 1) {
+            throw new RuntimeException("Could not dispatch query to more than one handler!");
+        }
+
+        return handlers.get(0).handle(query);
+    }
+}

--- a/account/account-query/src/main/java/com/techbank/account/query/infrastructure/handlers/AccountQueryHandler.java
+++ b/account/account-query/src/main/java/com/techbank/account/query/infrastructure/handlers/AccountQueryHandler.java
@@ -1,0 +1,66 @@
+package com.techbank.account.query.infrastructure.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.techbank.account.query.api.dto.EqualityType;
+import com.techbank.account.query.api.queries.FindAccountByHolderQuery;
+import com.techbank.account.query.api.queries.FindAccountByIdQuery;
+import com.techbank.account.query.api.queries.FindAccountsWithBalanceQuery;
+import com.techbank.account.query.api.queries.FindAllAccountsQuery;
+import com.techbank.account.query.api.queries.QueryHandler;
+import com.techbank.account.query.domain.BankAccount;
+import com.techbank.account.query.domain.BankAccountRepository;
+import com.techbank.cqrs.core.domain.BaseEntity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class AccountQueryHandler implements QueryHandler {
+
+    private final BankAccountRepository bankAccountRepository;
+
+    @Override
+    public List<BaseEntity> handle(final FindAllAccountsQuery query) {
+        final Iterable<BankAccount> accounts = bankAccountRepository.findAll();
+        
+        final List<BaseEntity> bankAccounts = new ArrayList<>();
+        
+        accounts.forEach(bankAccounts::add);
+
+        return bankAccounts;
+    }
+
+    @Override
+    public List<BaseEntity> handle(final FindAccountByIdQuery query) {
+        final List<BaseEntity> bankAccounts = new ArrayList<>();
+        
+        bankAccountRepository.findById(query.getId())
+            .ifPresent(bankAccounts::add);
+
+        return bankAccounts;
+    }
+
+    @Override
+    public List<BaseEntity> handle(final FindAccountByHolderQuery query) {
+        final List<BaseEntity> bankAccounts = new ArrayList<>();
+        
+        bankAccountRepository.findByAccountHolder(query.getAccountHolder())
+            .ifPresent(bankAccounts::add);
+
+        return bankAccounts;
+    }
+
+    @Override
+    public List<BaseEntity> handle(final FindAccountsWithBalanceQuery query) {
+        final List<BaseEntity> bankAccounts = query.getEqualityType() == EqualityType.LESS_THAN
+            ? bankAccountRepository.findByBalanceLessThan(query.getAmount())
+            : bankAccountRepository.findByBalanceGreaterThan(query.getAmount()); 
+
+        return bankAccounts;
+    }
+    
+}

--- a/cqrs-core/src/main/java/com/techbank/cqrs/core/handlers/EventSourcingHandler.java
+++ b/cqrs-core/src/main/java/com/techbank/cqrs/core/handlers/EventSourcingHandler.java
@@ -16,4 +16,10 @@ public interface EventSourcingHandler<T> {
      * Returns the latest state of the aggregate.
      */
     T getById(String aggregateId);
+
+    /**
+     * Republish all events for all aggregates according to their timeline.
+     * This is particularly useful when there is need for recreating the read-only views.
+     */
+    void republishEvents();
 }

--- a/cqrs-core/src/main/java/com/techbank/cqrs/core/infrastructure/EventStore.java
+++ b/cqrs-core/src/main/java/com/techbank/cqrs/core/infrastructure/EventStore.java
@@ -7,4 +7,5 @@ import com.techbank.cqrs.core.events.BaseEvent;
 public interface EventStore {
     void saveEvents(String aggregateId, Iterable<BaseEvent> events, int expectedVersion);
     List<BaseEvent> getEvents(String aggregateId);
+    List<String> getAggregateIds();
 }

--- a/cqrs-core/src/main/java/com/techbank/cqrs/core/infrastructure/QueryDispatcher.java
+++ b/cqrs-core/src/main/java/com/techbank/cqrs/core/infrastructure/QueryDispatcher.java
@@ -1,0 +1,15 @@
+package com.techbank.cqrs.core.infrastructure;
+
+import java.util.List;
+
+import com.techbank.cqrs.core.domain.BaseEntity;
+import com.techbank.cqrs.core.queries.BaseQuery;
+import com.techbank.cqrs.core.queries.QueryHandlerMethod;
+
+/**
+ * Allows for dispatching queries to the correct handlers.
+ */
+public interface QueryDispatcher {
+    <T extends BaseQuery> void registerHandler(Class<T> type, QueryHandlerMethod<T> handler);
+    <U extends BaseEntity> List<U> send(BaseQuery query);
+}

--- a/cqrs-core/src/main/java/com/techbank/cqrs/core/queries/BaseQuery.java
+++ b/cqrs-core/src/main/java/com/techbank/cqrs/core/queries/BaseQuery.java
@@ -1,0 +1,5 @@
+package com.techbank.cqrs.core.queries;
+
+public abstract class BaseQuery {
+    
+}

--- a/cqrs-core/src/main/java/com/techbank/cqrs/core/queries/QueryHandlerMethod.java
+++ b/cqrs-core/src/main/java/com/techbank/cqrs/core/queries/QueryHandlerMethod.java
@@ -1,0 +1,10 @@
+package com.techbank.cqrs.core.queries;
+
+import java.util.List;
+
+import com.techbank.cqrs.core.domain.BaseEntity;
+
+@FunctionalInterface
+public interface QueryHandlerMethod<T extends BaseQuery> {
+    List<BaseEntity> handle(T query);
+}

--- a/rest-client/find-account-by-balance.rest
+++ b/rest-client/find-account-by-balance.rest
@@ -1,0 +1,3 @@
+# GET http://localhost:5001/api/v1/bank-account-lookup/by-balance?balance=100&equalityType=GREATER_THAN HTTP/1.1
+
+GET http://localhost:5001/api/v1/bank-account-lookup/by-balance?balance=150&equalityType=LESS_THAN HTTP/1.1

--- a/rest-client/find-account-by-holder.rest
+++ b/rest-client/find-account-by-holder.rest
@@ -1,0 +1,1 @@
+GET http://localhost:5001/api/v1/bank-account-lookup/by-holder/Jane%20Doe HTTP/1.1

--- a/rest-client/find-account-by-id.rest
+++ b/rest-client/find-account-by-id.rest
@@ -1,0 +1,1 @@
+GET http://localhost:5001/api/v1/bank-account-lookup/by-id/127c9aae-c264-42a8-b7b4-72415e0c9cd0 HTTP/1.1

--- a/rest-client/find-all-accounts.rest
+++ b/rest-client/find-all-accounts.rest
@@ -1,0 +1,1 @@
+GET http://localhost:5001/api/v1/bank-account-lookup/ HTTP/1.1

--- a/rest-client/restore-read-db.rest
+++ b/rest-client/restore-read-db.rest
@@ -1,0 +1,5 @@
+POST http://localhost:5000/api/v1/admin/restore-read-db HTTP/1.1
+content-type: application/json
+
+{
+}


### PR DESCRIPTION
This PR introduce the ability, though a specific command, to trigger the replay of the aggregate events for all active bank accounts.

This is usefull when the read-only views have to be reacreated or there is need for a change in the database technology (e.g., move from MySQL to Postgres)